### PR TITLE
Add inventory status styling on page load

### DIFF
--- a/resources/views/components/inventory/inventoryContainer.blade.php
+++ b/resources/views/components/inventory/inventoryContainer.blade.php
@@ -1,7 +1,11 @@
 @props(['inventory'])
+@php
+    $inventoryCapacity = 18;
+    $isInventoryFull = count($inventory) === $inventoryCapacity;
+@endphp
 <x-borderInterfaceContainer id="inventory" class="w-[29%] float-right h-[600px] mt-0 z-20">
-    <p class="text-white mb-4">Inventory <span id="inventory-status">
-            {{ '(' . count($inventory) . ' / ' . '18' . ')' }}</span>
+    <p class="text-white mb-4">Inventory <span id="inventory-status" @class(['not-able-color' => $isInventoryFull])>
+            {{ sprintf('(%d / %d)', count($inventory), $inventoryCapacity) }}</span>
     </p>
     <x-inventory.inventoryItems :$inventory />
 </x-borderInterfaceContainer>


### PR DESCRIPTION
## PR Type ⚙️
* [ ] Refactor
* [x] Feature
* [ ] Bugfix
* [ ] Optimizing
* [ ] Docs
* [ ] Other

## Description :pen:
Previously on page load the inventory status wouldn't be marked red like it is toggled in Inventory.ts. This PR introduces this.

## Impact :telescope:
Better UI

Inventory functionality should at some point be refactored into a vue component which deals with everything inventory related. I have outlined some thoughts in the item #57889459

## Checklist :clipboard:

* [x] All tests are passing
* [x] I have updated relevant model docblocks
