### PR TITLE
Fix bug when segment doesn't include client_events

### DIFF
--- a/resources/js/clientScripts/conversation.ts
+++ b/resources/js/clientScripts/conversation.ts
@@ -156,7 +156,7 @@ export class conversation {
     }
 
     private static handleClientEvents() {
-        if (this.currentConversationSegment.client_events.length > 0) {
+        if (this.currentConversationSegment.client_events?.length > 0) {
             this.currentConversationSegment.client_events.forEach(
                 clientEvent => {
                     switch (clientEvent) {
@@ -369,7 +369,7 @@ interface conversationSegmentResponse {
 interface ConversationSegment {
     header?: string;
     options: ConversationOption[];
-    client_events: ConversationClientEvent[];
+    client_events?: ConversationClientEvent[];
 }
 interface ConversationOption {
     person: string | null;


### PR DESCRIPTION
## PR Type ⚙️
* [ ] Refactor
* [ ] Feature
* [x] Bugfix
* [ ] Optimizing
* [ ] Docs
* [ ] Other

## Description :pen:
Fixed bug where a conversation segment without client_events would crash

## Impact :telescope:
More flexible conversation structure

## Checklist :clipboard:

* [x] All tests are passing
* [x] I have updated relevant model docblocks
