### PR TITLE
feat: add generic for request object on post methods

### DIFF
--- a/resources/js/AdvApi.ts
+++ b/resources/js/AdvApi.ts
@@ -63,9 +63,9 @@ export class AdvApi extends BaseAxios {
         return BaseAxios.get<T>(url);
     }
 
-    public static async post<T = advAPIResponse>(
+    public static async post<T = advAPIResponse, K extends object = object>(
         url: string,
-        data: object = {},
+        data: K,
     ): Promise<T> {
         if (this.interceptorsConfigured === false) this.init();
 

--- a/resources/js/CustomFetchApi.ts
+++ b/resources/js/CustomFetchApi.ts
@@ -6,7 +6,10 @@ export class CustomFetchApi extends BaseAxios {
         return BaseAxios.get<T>(url);
     }
 
-    public static async post<T>(url: string, data: Object): Promise<T> {
+    public static async post<T, K extends object = object>(
+        url: string,
+        data: K,
+    ): Promise<T> {
         return BaseAxios.post<T>(url, data);
     }
 }


### PR DESCRIPTION
## Description :pen:
This PR adds generic on post method on CustomFetchApi & AdvApi. Previously one would need to specify a data object like this
```javascript
const data: baz = {
  bar: string;
};
AdvApi.post<foo>('/foo, data);
``` 

With the new feature the same can be rewritten like this
```javascript
const data = {
  bar: string;
};
AdvApi.post<foo, baz>('/foo, data);
``` 
This brings consistensy to where one might find the typings for the particular request.

## Checklist :clipboard:

* [ x ] All tests are passing
