### PR TITLE
refactor(WorldLoaderController): use default response

### DIFF
--- a/resources/js/advclient.ts
+++ b/resources/js/advclient.ts
@@ -19,7 +19,7 @@ import { jsUcWords } from './utilities/uppercase';
 import { setUpTabList } from './utilities/tabs';
 import { AssetPaths } from './clientScripts/ImagePath';
 import { GetWorldResponse } from './types/Responses/WorldLoaderResponse';
-import { initErrorHandler } from './base/ErrorHandler';
+import { initErrorHandler, reportCatchError } from './base/ErrorHandler';
 
 const CookieTicket = {
     checkCookieTicket(cookieNoob = 'getOut') {
@@ -138,12 +138,11 @@ export class Game {
 
     public static async getWorld() {
         this.pauseWorld();
-
-        await CustomFetchApi.get<GetWorldResponse>('/worldloader').then(
-            response => {
+        await CustomFetchApi.get<GetWorldResponse>('/worldloader')
+            .then(response => {
                 this.loadWorld(response);
-            },
-        );
+            })
+            .catch(error => reportCatchError(error));
     }
 
     public static async setWorld(parameters: loadWorldParamters = {}) {
@@ -159,12 +158,11 @@ export class Game {
             data.is_new_map_string = true;
         }
 
-        await CustomFetchApi.post<GetWorldResponse>(
-            '/worldloader/change',
-            data,
-        ).then(async response => {
-            await this.loadWorld(response, parameters);
-        });
+        await CustomFetchApi.post<GetWorldResponse>('/worldloader/change', data)
+            .then(async response => {
+                await this.loadWorld(response, parameters);
+            })
+            .catch(error => reportCatchError(error));
     }
 
     private static pauseWorld() {


### PR DESCRIPTION
## Description :pen:

This PR refactors the response returned from WorldLoaderController. It was using advResponse but in no way did it need to.
Add some missing catch blocks when the promise is rejected in advClient.

## Checklist :clipboard:

* [ x ] All tests are passing
