### PR TITLE
refactor: make exit button be positioned absolute

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -465,7 +465,6 @@ button:focus {
     z-index: var(--newsZIndex);
     width: 68%;
     padding: 1%;
-    display: flex;
     transition: top 0.5s ease-out;
     top: 200px;
     box-shadow: 0px 0px 30px 15px;

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -4,11 +4,12 @@
 <div id="news">
 </div>
 <div id="news_content" class="gap-x-2">
-    <div id="news_content_side_panel" class="hidden w-1/4">
-
+    <div class="flex grow">
+        <div id="news_content_side_panel" class="hidden w-1/4">
+            
+        </div>
+        <div id="news_content_main_content" class="mb-2 mt-2 grow">    
+        </div>
     </div>
-    <div id="news_content_main_content" class="mb-2 mt-2 grow">
-
-    </div>
-    <img class="cont_exit" src="{{ asset('images/exit.png') }}" width="20px" height="20px" />
+    <img class="cont_exit absolute top-4 right-4" src="{{ asset('images/exit.png') }}" width="20px" height="20px" />
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,4 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
     content: [
         './resources/views/**/*.blade.php',
         './resources/views/errors/*.blade.php',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
             "@/*": ["./resources/js/*"]
         },
     },
-    "include": ["resources/js/**/*.ts", "resources/js/**/*.vue"],
+    "include": ["resources/js/**/*.ts", "resources/js/**/*.vue", "tailwind.config.js"],
     "exclude": ["node_modules", "vendor"]
 }


### PR DESCRIPTION
## Description :pen:

Exit button was taking too much space in the news_content section. No need for the button to be position sticky either

## Checklist :clipboard:

* [x] All tests are passing
