### PR TITLE
fix: wrong structure returned from toStoreItemResponse

### DIFF
--- a/app/Abstracts/AbstractStore.php
+++ b/app/Abstracts/AbstractStore.php
@@ -25,7 +25,7 @@ abstract class AbstractStore
 
     public function toStoreItemResponse(StoreResource $StoreResource): JsonResponse
     {
-        $data = ['store_items' => $StoreResource->store_items];
+        $data = ['store_items' => $StoreResource->toStoreItemArray()];
 
         return response()->json(['data' => $data], 200);
     }

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -74,4 +74,15 @@ class StoreResource extends Resource
             'infinite_amount' => $this->infinite_amount,
         ];
     }
+
+    public function toStoreItemArray(): array
+    {
+        $store_items = [];
+
+        foreach ($this->store_items as $key => $item) {
+            array_push($store_items, $item->toArray());
+        }
+
+        return $store_items;
+    }
 }

--- a/tests/feature/Buildings/SmithyTest.php
+++ b/tests/feature/Buildings/SmithyTest.php
@@ -33,8 +33,11 @@ class SmithyTest extends TestCase
         $response = $this->get('/smithy/store');
 
         $response->assertStatus(200);
-
-        $response->json();
+        $response->assertJsonStructure(([
+            'data' => [
+                'store_items',
+            ],
+        ]));
     }
 
     /**

--- a/tests/feature/Stores/SmithyStoreTest.php
+++ b/tests/feature/Stores/SmithyStoreTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Http\Resources\StoreItemResource;
+use App\Http\Resources\StoreResource;
+use App\Stores\SmithyStore;
+use Tests\TestCase;
+
+final class SmithyStoreTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_make_store()
+    {
+        /**
+         * @var SmithyStore $SmithyStore
+         */
+        $SmithyStore = app()->make(SmithyStore::class);
+        $StoreResource = $SmithyStore->makeStore($this->RandomUser);
+        $this->assertEquals($StoreResource::class, StoreResource::class);
+    }
+
+    public function test_to_store_item_response()
+    {
+        /**
+         * @var SmithyStore $SmithyStore
+         */
+        $SmithyStore = app()->make(SmithyStore::class);
+        $storeResource = $SmithyStore->makeStore($this->RandomUser);
+        $response = $SmithyStore->toStoreItemResponse($storeResource);
+
+        $keys = array_keys((new StoreItemResource([]))->toArray());
+
+        $this->assertEqualsCanonicalizing([
+            ...$keys
+        ], array_keys($response->getData(true)['data']['store_items'][0]));
+    }
+}


### PR DESCRIPTION
## Description :pen:

toStoreItemResponse returned StoreItemResource but weren't mapped to an array.

## Checklist :clipboard:

* [x] All tests are passing
