### PR TITLE
fix(stockpile): menu not appear/disappearing correctly

### DIFF
--- a/resources/js/buildingScripts/stockpile.ts
+++ b/resources/js/buildingScripts/stockpile.ts
@@ -116,7 +116,7 @@ const stockpileModule = {
       .then(async res => {
         document.getElementById('stockpile-list').innerHTML =
           res.html.stockpile;
-        document.getElementById('stck_menu').style.visibility = 'hidden';
+        document.getElementById('stck_menu')?.classList.add('hidden');
 
         stckMenuInput.value = '';
 
@@ -144,7 +144,7 @@ const stockpileModule = {
 
     // Insert item name at the first li
     document.getElementById('stck-current-item').innerHTML = item;
-    menu.style.visibility = 'visible';
+    menu?.classList.remove('hidden');
     // Declare menu top by measuring the positon from top of parent and also if inventory/stockpile is scrolled
     let menuTop;
     const listItems = list.querySelectorAll('li');
@@ -197,7 +197,7 @@ const stockpileModule = {
   },
   hideMenu() {
     const menu = document.getElementById('stck_menu');
-    menu.style.visibility = 'hidden';
+    menu?.classList.add('hidden');
     document.getElementById('news_content').appendChild(menu);
   },
   onClose() {

--- a/resources/views/components/stockpile/stockpileMenu.blade.php
+++ b/resources/views/components/stockpile/stockpileMenu.blade.php
@@ -1,5 +1,5 @@
 <div id="stck_menu"
-    class="visible absolute z-10 w-36 max-w-[144px] overflow-scroll rounded-md border-2 border-stone-600 bg-stone-700 py-2 text-center text-xs text-white drop-shadow-xl">
+    class="absolute z-10 w-36 max-w-[144px] overflow-scroll rounded-md border-2 border-stone-600 bg-stone-700 py-2 text-center text-xs text-white drop-shadow-xl hidden">
     <p id="stck-current-item" class="mb-2 mt-0 font-bold"></p>
     <ul id="stck-menu-option-list">
         <x-stockpile.stockpileMenuItem :action-amount="'1'" />


### PR DESCRIPTION
## Description :pen:

The blade was using `visible` tailwind class while the JS was using `.style`. This fixes so that the menu is appearing/disappearing correctly.
