### PR TITLE
feat: add page wrapper for in-blade vue components

### DIFF
--- a/resources/js/clientScripts/inputHandler.ts
+++ b/resources/js/clientScripts/inputHandler.ts
@@ -27,6 +27,7 @@ import { createApp } from 'vue';
 import { ItemSelector } from '@/ItemSelector';
 import ArmoryPage from '@/ui/pages/ArmoryPage.vue';
 import { useConversationStore } from '@/ui/stores/ConversationStore';
+import PageWrapper from '@/ui/components/PageWrapper.vue';
 
 enum Buildings {
   BAKERY = 'bakery',
@@ -210,6 +211,7 @@ export const inputHandler: IInputHandler = {
           const app = createApp({
             AppVue,
             components: {
+              PageWrapper,
               ArmoryPage,
             },
           });
@@ -269,7 +271,7 @@ export const inputHandler: IInputHandler = {
             }
             this.currentBuildingModule = data;
           });
-        } else if (isCurrentVuePage === false) {
+        } else if (!isCurrentVuePage) {
           switch (building) {
             case 'archeryshop':
               this.currentBuildingModule = archeryShopModule;

--- a/resources/js/ui/components/PageWrapper.vue
+++ b/resources/js/ui/components/PageWrapper.vue
@@ -1,0 +1,16 @@
+<template>
+  <component :is="page" v-bind="stateProps" />
+</template>
+
+<script setup lang="ts">
+/** Wrapper for in-blade vue page components */
+import { reactive } from 'vue';
+
+interface Props {
+  page: string;
+  initProps?: Record<string, unknown>;
+}
+
+const { initProps } = defineProps<Props>();
+const stateProps = reactive(initProps || {});
+</script>


### PR DESCRIPTION
## Description :pen:

Simple wrapper to make working with in-blade vue components a bit easier. Mimicks the way Inertia does and prevent having to set props as "initProps". E.g when working with defineModel and other operations which would violate mutating prop principle.

Also makes a neat trick of making the props reactive in PageWrapper so that the dev experience is much much easier.
Can be used for other things in the future.
