### PR TITLE
refactor: Unify item components

### DIFF
--- a/resources/js/buildingScripts/stockpile.ts
+++ b/resources/js/buildingScripts/stockpile.ts
@@ -134,7 +134,7 @@ const stockpileModule = {
     const menu = document.getElementById('stck_menu');
     const list = document.getElementById('stck-menu-option-list');
     let item;
-    if (element.className == 'inventory_item') {
+    if (element?.classList.contains('inventory_item')) {
       item = element?.querySelectorAll('figcaption .tooltip_item')[0].innerHTML;
       document.getElementById('inventory').appendChild(menu);
     } else {

--- a/resources/js/ui/components/Inventory/InventoryItemWrapper.vue
+++ b/resources/js/ui/components/Inventory/InventoryItemWrapper.vue
@@ -1,52 +1,26 @@
 <template>
-  <div class="inventory_item">
-    <figure
-      @click="handleEvent($event, item.item)"
-      v-on="
-        inventoryStore.inventoryItemEvent === null
-          ? {
-              mouseleave: () => itemTitle.hide(),
-              mouseover: e => itemTitle.show(e),
-            }
-          : {}
-      "
-    >
-      <img :src="'/images/' + item.item + '.png'" alt="inventory-item" />
-      <figcaption class="tooltip">
-        <span class="tooltip_item">{{ jsUcWords(item.item) }}</span>
-        <br />
-        x {{ item.amount }}
-      </figcaption>
-    </figure>
-    <span class="item_amount">
-      {{ itemAmountWithDelimiter }}
-    </span>
-  </div>
+  <BaseItem
+    class="inventory_item"
+    :item="item.item"
+    :amount="item.amount"
+    @click="handleEvent($event, item.item)"
+  />
 </template>
 
 <script setup lang="ts">
 import type { InventoryItem } from '@/types/InventoryItem';
-import { jsUcWords } from '@/utilities/uppercase';
-import { computed } from 'vue';
-import { itemTitle } from '@/utilities/itemTitle';
 import { useInventoryStore } from '@/ui/stores/InventoryStore';
 import stockpileModule from '@/buildingScripts/stockpile';
+import BaseItem from '../base/BaseItem.vue';
 
 interface Props {
   item: InventoryItem;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 
 const inventoryStore = useInventoryStore();
 
-const itemAmountWithDelimiter = computed(() => {
-  if (props.item.amount > 1000) {
-    return `${(props.item.amount / 1000).toFixed(1)} k`;
-  }
-
-  return props.item.amount;
-});
 const handleEvent = (e: Event, itemName: string) => {
   if (inventoryStore.inventoryItemEvent === null) {
     return;

--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="item">
-    <figure @mouseleave="itemTitle.hide()" @mouseover="itemTitle.show($event)">
+    <figure
+      @mouseleave="disableTooltip ? itemTitle.hide() : null"
+      @mouseover="disableTooltip ? null : itemTitle.show($event)"
+    >
       <img :src="'/images/' + item + '.png'" alt="inventory-item" />
       <figcaption class="tooltip">
         <span class="tooltip_item">{{ jsUcWords(item) }}</span>
@@ -11,7 +14,7 @@
         </span>
       </figcaption>
     </figure>
-    <span v-if="showAmountInput && amount !== undefined" class="item_amount">
+    <span v-if="showAmount && amount !== undefined" class="item_amount">
       {{ itemAmountWithDelimiter }}
     </span>
   </div>
@@ -25,13 +28,15 @@ import { formatItemAmount } from '@/utilities/formatters';
 import type { Item } from '@/types/Item';
 
 interface Props {
+  disableTooltip?: boolean;
   item: Item['item'];
   amount?: number;
-  showAmountInput?: boolean;
+  showAmount?: boolean;
 }
 
 const {
-  showAmountInput = true,
+  disableTooltip = false,
+  showAmount = true,
   item,
   amount = undefined,
 } = defineProps<Props>();


### PR DESCRIPTION
## Description :pen:

This PR refactors so that `InventoryItemWrapper` uses `BaseItem` to prevent code duplication.
