### PR TITLE
fix(InventoryStore): method marked as async

### DIFF
--- a/resources/js/ui/stores/InventoryStore.ts
+++ b/resources/js/ui/stores/InventoryStore.ts
@@ -29,7 +29,7 @@ export const useInventoryStore = defineStore('inventory', {
     setInventoryItemEvent(event: InventoryItemEvent) {
       this.inventoryItemEvent = event;
     },
-    async setShouldUpdateInventory(val: boolean) {
+    setShouldUpdateInventory(val: boolean) {
       this.shouldUpdateInventory = val;
     },
     setInventoryItems(items: InventoryItem[]) {


### PR DESCRIPTION
## Description :pen:

This PR fixes an bug where `setShouldUpdateInventory` was marked wrongly marked as async. This caused eslint to throw errors with https://typescript-eslint.io/rules/no-floating-promises/
