### PR TITLE
chore: no-useless-default-assignment wrongly reports in vue sfc

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,4 +30,10 @@ export default defineConfigWithVueTs(
       '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
+  {
+    files: ['**/*.vue'],
+    rules: {
+      '@typescript-eslint/no-useless-default-assignment': 'off',
+    },
+  },
 );


### PR DESCRIPTION
## Description :pen:

This PR instructs eslint to skip `no-useless-default-assignment` for vue sfc. It wrongly reports optional parameters as non optional
