### PR TITLE
refactor: Make animation speed frame-rate independent

### DIFF
--- a/resources/js/__tests__/advclient.test.ts
+++ b/resources/js/__tests__/advclient.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, beforeEach, vi, test } from 'vitest';
+
+// Mock all canvas/game-loop dependencies so the module loads in jsdom.
+// Game.update returns early when gameState !== 'playing', so only
+// viewport.zoom needs a real value for the delta tests.
+vi.mock('@/clientScripts/canvasText', () => ({
+  loadingCanvas: { opacity: 0, loadingAnimationTracker: { start: vi.fn() } },
+  canvasTextHeader: { setDraw: vi.fn() },
+}));
+vi.mock('@/clientScripts/clientOverlayInterface', () => ({
+  ClientOverlayInterface: { setup: vi.fn() },
+}));
+vi.mock('@/clientScripts/collision', () => ({ collisionCheck: vi.fn() }));
+vi.mock('@/clientScripts/controls', () => ({ controls: { setup: vi.fn() } }));
+vi.mock('@/clientScripts/gameEventHandler', () => ({
+  eventHandler: { checkEvent: vi.fn() },
+}));
+vi.mock('@/clientScripts/gamePieces', () => ({
+  GamePieces: {
+    player: {
+      xMovement: 0,
+      yMovement: 0,
+      movementSpeed: 0,
+      speedX: 0,
+      speedY: 0,
+      xTracker: 0,
+      yTracker: 0,
+      animationEnd: true,
+      checkPosition: vi.fn(() => false),
+      newPos: vi.fn(),
+    },
+    init: vi.fn(),
+    drawStaticPieces: vi.fn(),
+    drawDaqloons: vi.fn(),
+    checkViewportGamePieces: vi.fn(),
+    reset: vi.fn(),
+    loadAssets: vi.fn(),
+  },
+}));
+vi.mock('@/clientScripts/pause', () => ({
+  pauseManager: { resumeGame: vi.fn() },
+}));
+vi.mock('@/clientScripts/viewport', () => ({
+  default: {
+    zoom: 1.2,
+    resetSpriteLayer: vi.fn(),
+    drawBackground: vi.fn(),
+    adjustViewport: vi.fn(),
+    setup: vi.fn(),
+  },
+}));
+vi.mock('@/CustomFetchApi', () => ({
+  CustomFetchApi: { get: vi.fn(), post: vi.fn() },
+}));
+vi.mock('@/ui/stores/ConversationStore', () => ({
+  useConversationStore: () => ({ isActive: false }),
+}));
+vi.mock('@/gameEventsBus', () => ({
+  gameEventBus: { emit: vi.fn(), subscribe: vi.fn() },
+}));
+vi.mock('@/utilities/formatters', () => ({ formatLocationName: vi.fn() }));
+vi.mock('@/utilities/tabs', () => ({ setUpTabList: vi.fn() }));
+vi.mock('@/base/ErrorHandler', () => ({
+  initErrorHandler: vi.fn(),
+  reportCatchError: vi.fn(),
+}));
+
+import { Game } from '@/advclient';
+
+const ZOOM = 1.2;
+
+// Helper: run N simulated frames at a fixed interval, return delta each time
+function simulateFrames(count: number, msPerFrame: number): number[] {
+  const deltas: number[] = [];
+  for (let i = 1; i <= count; i++) {
+    Game.update(i * msPerFrame);
+    deltas.push(Game.properties.delta);
+  }
+  return deltas;
+}
+
+describe('Game.properties.delta', () => {
+  beforeEach(() => {
+    Game.properties.timestamp = 0;
+    Game.properties.gameState = 'loading';
+  });
+
+  test('equals elapsed seconds divided by zoom', () => {
+    Game.properties.timestamp = 1000;
+    Game.update(1016.67); // ~16.67 ms later
+
+    expect(Game.properties.delta).toBeCloseTo(0.01667 / ZOOM, 4);
+  });
+
+  test('scales with zoom — slower delta at higher zoom', () => {
+    Game.properties.timestamp = 0;
+    Game.update(16.67);
+
+    expect(Game.properties.delta).toBeCloseTo(0.01667 / ZOOM, 4);
+    expect(Game.properties.delta).toBeLessThan(0.01667); // always less than raw seconds
+  });
+
+  test('is capped when frame time spikes', () => {
+    Game.properties.timestamp = 0;
+    Game.update(500); // 500 ms gap — way over the 0.08 s cap
+
+    const expectedDelta = Math.round(0.16 / ZOOM) * 2;
+    expect(Game.properties.delta).toBe(expectedDelta);
+  });
+});
+
+describe('delta frame-rate independence', () => {
+  beforeEach(() => {
+    Game.properties.timestamp = 0;
+    Game.properties.gameState = 'loading';
+  });
+
+  test('accumulates to the same total over the same wall time at 60 vs 30 FPS', () => {
+    // 60 FPS: 10 frames × 16.67 ms = ~167 ms of wall time
+    const deltas60 = simulateFrames(10, 1000 / 60);
+    const total60 = deltas60.reduce((a, b) => a + b, 0);
+
+    Game.properties.timestamp = 0;
+
+    // 30 FPS: 5 frames × 33.33 ms = ~167 ms of wall time
+    const deltas30 = simulateFrames(5, 1000 / 30);
+    const total30 = deltas30.reduce((a, b) => a + b, 0);
+
+    expect(total60).toBeCloseTo(0.167 / ZOOM, 2);
+    expect(total30).toBeCloseTo(0.167 / ZOOM, 2);
+    expect(total60).toBeCloseTo(total30, 3);
+  });
+
+  test('animTimer fires within one frame of threshold regardless of FPS', () => {
+    const EXAMPLE_ANIM_DURATION = 0.167;
+    const deltaPerFrame60 = 1 / 60 / ZOOM;
+    const deltaPerFrame30 = 1 / 30 / ZOOM;
+
+    // Count frames needed to reach threshold at 60 FPS
+    let timer = 0;
+    let frames60 = 0;
+    while (timer < EXAMPLE_ANIM_DURATION) {
+      timer += deltaPerFrame60;
+      frames60++;
+    }
+    const elapsed60 = frames60 * deltaPerFrame60;
+
+    // Count frames needed to reach threshold at 30 FPS
+    timer = 0;
+    let frames30 = 0;
+    while (timer < EXAMPLE_ANIM_DURATION) {
+      timer += deltaPerFrame30;
+      frames30++;
+    }
+    const elapsed30 = frames30 * deltaPerFrame30;
+
+    // 30 FPS needs half as many frames as 60 FPS
+    expect(frames30).toBe(Math.ceil(frames60 / 2));
+
+    // Both fire within one frame's overshoot of the threshold
+    expect(elapsed60 - EXAMPLE_ANIM_DURATION).toBeLessThan(deltaPerFrame60);
+    expect(elapsed30 - EXAMPLE_ANIM_DURATION).toBeLessThan(deltaPerFrame30);
+
+    // Neither fires before the threshold
+    expect(elapsed60 - deltaPerFrame60).toBeLessThan(EXAMPLE_ANIM_DURATION);
+    expect(elapsed30 - deltaPerFrame30).toBeLessThan(EXAMPLE_ANIM_DURATION);
+  });
+});

--- a/resources/js/advclient.ts
+++ b/resources/js/advclient.ts
@@ -22,7 +22,6 @@ export type AdvClientEvents = {
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class Game {
   public static properties: GameProperties = {
-    duration: 0,
     requestId: 0,
     pauseID: null,
     timestamp: 0,
@@ -37,7 +36,6 @@ export class Game {
     inBuilding: false,
     checkingPerson: 'none',
     delta: 0,
-    rawDelta: 0,
   };
 
   public static worldData: GetWorldResponse['data'];
@@ -273,12 +271,10 @@ export class Game {
   }
 
   public static update = (timestamp: number) => {
-    Game.properties.rawDelta =
-      (timestamp - Game.properties.timestamp) / 1000;
-    Game.properties.delta = Game.properties.rawDelta / viewport.zoom;
+    Game.properties.delta =
+      (timestamp - Game.properties.timestamp) / 1000 / viewport.zoom;
     if (Game.properties.delta > 0.08) {
       Game.properties.delta = Math.round(0.16 / viewport.zoom) * 2;
-      Game.properties.rawDelta = Game.properties.delta * viewport.zoom;
     }
     Game.properties.timestamp = timestamp;
     if (Game.properties.gameState !== 'playing') {
@@ -331,7 +327,6 @@ export class Game {
     if (GamePieces.player.checkPosition()) {
       Game.getNextWorld();
     }
-    Game.properties.duration++;
     Game.properties.requestId = window.requestAnimationFrame(Game.update);
   };
 }

--- a/resources/js/advclient.ts
+++ b/resources/js/advclient.ts
@@ -44,18 +44,6 @@ export class Game {
     return this.properties[val];
   }
 
-  /**
-   * Threshold 60 will be around 1 second
-   * @returns boolean
-   */
-  public static isGameDuration(threshold: number) {
-    if (this.properties.duration % threshold === 0) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
   public static setGameState(state: string) {
     // TODO: Fix enum here
     if (

--- a/resources/js/advclient.ts
+++ b/resources/js/advclient.ts
@@ -37,6 +37,7 @@ export class Game {
     inBuilding: false,
     checkingPerson: 'none',
     delta: 0,
+    rawDelta: 0,
   };
 
   public static worldData: GetWorldResponse['data'];
@@ -272,10 +273,12 @@ export class Game {
   }
 
   public static update = (timestamp: number) => {
-    Game.properties.delta =
-      (timestamp - Game.properties.timestamp) / 1000 / viewport.zoom;
+    Game.properties.rawDelta =
+      (timestamp - Game.properties.timestamp) / 1000;
+    Game.properties.delta = Game.properties.rawDelta / viewport.zoom;
     if (Game.properties.delta > 0.08) {
       Game.properties.delta = Math.round(0.16 / viewport.zoom) * 2;
+      Game.properties.rawDelta = Game.properties.delta * viewport.zoom;
     }
     Game.properties.timestamp = timestamp;
     if (Game.properties.gameState !== 'playing') {

--- a/resources/js/gamepieces/Daqloon.ts
+++ b/resources/js/gamepieces/Daqloon.ts
@@ -56,7 +56,7 @@ export class Daqloon implements MovingGameObject {
   spawn = true;
   nearbyPlayer = true;
   moveX = 0;
-  hitMessage = -1;
+  hitMessageTimer = -1;
   animTimer = 0;
   wanderTimer = 0;
   // TODO: Fix object
@@ -109,7 +109,7 @@ export class Daqloon implements MovingGameObject {
 
     const damage = getRandomInteger(0, GamePieces.player.attackDamage);
     this.health -= damage;
-    this.hitMessage = Game.properties.duration;
+    this.hitMessageTimer = 0;
     viewport.drawText(
       '18px Times New Roman',
       '#FFFFFF',
@@ -185,12 +185,12 @@ export class Daqloon implements MovingGameObject {
         this.drawY - GamePieces.player.yMovement * viewport.scale,
       );
     }
-    if (
-      this.hitMessage !== -1 &&
-      Game.properties.duration - this.hitMessage > 10
-    ) {
-      this.hitMessage = -1;
-      viewport.resetTextLayer();
+    if (this.hitMessageTimer !== -1) {
+      this.hitMessageTimer += Game.properties.rawDelta;
+      if (this.hitMessageTimer > 0.167) {
+        this.hitMessageTimer = -1;
+        viewport.resetTextLayer();
+      }
     }
     this.setDiameter();
     this.resetDirections();

--- a/resources/js/gamepieces/Daqloon.ts
+++ b/resources/js/gamepieces/Daqloon.ts
@@ -10,6 +10,9 @@ import { collisionCheck } from '../clientScripts/collision';
 import { AssetPaths } from '../clientScripts/ImagePath';
 
 export class Daqloon implements MovingGameObject {
+  ANIM_IDLE_DURATION = 0.167; // ~6 frames/sec  — spawn / death / idle cycle
+  ANIM_ATTACK_DURATION = 0.1; // 10 frames/sec  — attack animation
+  ANIM_WANDER_DURATION = 0.5; // 2 frames/sec   — idle direction repick
   id: number;
   index = 1;
   attackDamage = 15;
@@ -54,6 +57,8 @@ export class Daqloon implements MovingGameObject {
   nearbyPlayer = true;
   moveX = 0;
   hitMessage = -1;
+  animTimer = 0;
+  wanderTimer = 0;
   // TODO: Fix object
   fighting_area = null;
 
@@ -222,10 +227,12 @@ export class Daqloon implements MovingGameObject {
     if (this.health > 0) {
       this.calculateMovement();
     }
+    this.animTimer += Game.properties.rawDelta;
     if (this.currentAnimation === 'damage') {
       this.setStartAnimationPoint('idle');
     } else if (this.spawn && !this.dead) {
-      if (Game.properties.duration % 10 === 0) {
+      if (this.animTimer >= this.ANIM_IDLE_DURATION) {
+        this.animTimer = 0;
         if (this.spriteXIndex >= 2) {
           this.spriteYIndex = 2;
           this.spawn = false;
@@ -236,7 +243,8 @@ export class Daqloon implements MovingGameObject {
           this.spriteXIndex++;
         }
       }
-    } else if (this.dead && Game.properties.duration % 10 === 0) {
+    } else if (this.dead && this.animTimer >= this.ANIM_IDLE_DURATION) {
+      this.animTimer = 0;
       // If spriteXIndex is 5, the death animation is complete
       this.setStartAnimationPoint('death');
       if (this.spriteXIndex == 5) {
@@ -249,11 +257,12 @@ export class Daqloon implements MovingGameObject {
       }
       this.spriteXIndex++;
     } else if (
-      Game.properties.duration % 6 === 0 &&
+      this.animTimer >= this.ANIM_ATTACK_DURATION &&
       this.attack &&
       !this.dead &&
       !this.spawn
     ) {
+      this.animTimer = 0;
       // Set start xIndex for attack animation
       if (this.spriteXIndex < 5) {
         this.spriteXIndex = 5;
@@ -270,11 +279,12 @@ export class Daqloon implements MovingGameObject {
         }
       }
     } else if (
-      Game.properties.duration % 10 === 0 &&
+      this.animTimer >= this.ANIM_IDLE_DURATION &&
       !this.dead &&
       !this.spawn &&
       !this.attack
     ) {
+      this.animTimer = 0;
       this.spriteXIndex++;
       if (this.spriteXIndex > 4) {
         this.spriteXIndex = 1;
@@ -335,7 +345,9 @@ export class Daqloon implements MovingGameObject {
         this.spriteYIndex = 1;
       }
     } else {
-      if (Game.properties.duration % 30 === 0) {
+      this.wanderTimer += Game.properties.rawDelta;
+      if (this.wanderTimer >= this.ANIM_WANDER_DURATION) {
+        this.wanderTimer = 0;
         this.spriteYIndex = getRandomInteger(0, 1);
         this.moveX = getRandomInteger(0, 2);
       }

--- a/resources/js/gamepieces/Daqloon.ts
+++ b/resources/js/gamepieces/Daqloon.ts
@@ -186,7 +186,7 @@ export class Daqloon implements MovingGameObject {
       );
     }
     if (this.hitMessageTimer !== -1) {
-      this.hitMessageTimer += Game.properties.rawDelta;
+      this.hitMessageTimer += Game.properties.delta;
       if (this.hitMessageTimer > 0.167) {
         this.hitMessageTimer = -1;
         viewport.resetTextLayer();
@@ -227,7 +227,7 @@ export class Daqloon implements MovingGameObject {
     if (this.health > 0) {
       this.calculateMovement();
     }
-    this.animTimer += Game.properties.rawDelta;
+    this.animTimer += Game.properties.delta;
     if (this.currentAnimation === 'damage') {
       this.setStartAnimationPoint('idle');
     } else if (this.spawn && !this.dead) {
@@ -345,7 +345,7 @@ export class Daqloon implements MovingGameObject {
         this.spriteYIndex = 1;
       }
     } else {
-      this.wanderTimer += Game.properties.rawDelta;
+      this.wanderTimer += Game.properties.delta;
       if (this.wanderTimer >= this.ANIM_WANDER_DURATION) {
         this.wanderTimer = 0;
         this.spriteYIndex = getRandomInteger(0, 1);

--- a/resources/js/gamepieces/Player.ts
+++ b/resources/js/gamepieces/Player.ts
@@ -7,12 +7,13 @@ import { controls } from '../clientScripts/controls';
 import { Game } from '../advclient';
 import viewport from '../clientScripts/viewport';
 import { GamePieces } from '../clientScripts/gamePieces';
-import { HUD } from '../clientScripts/HUD';
 import { AssetPaths } from '../clientScripts/ImagePath';
 import { addModuleTester } from '@/devtools/ModuleTester';
 import { gameEventBus } from '@/gameEventsBus';
 
 export class Player implements MovingGameObject {
+  ANIM_WALK_DURATION = 0.167; // ~6 frames/sec  — standard walk/idle cycle
+  ANIM_ATTACK_DURATION = 0.033; // ~30 frames/sec — snappy attack steps
   width = 36;
   height = 36;
   speedX = 0;
@@ -55,6 +56,7 @@ export class Player implements MovingGameObject {
   attackedBy = -1;
   hunted = false;
   loopIndex = 0;
+  animTimer = 0;
   counter = 0;
   direction = 'none';
   loopArray = [0, 1, 0, 2];
@@ -289,6 +291,7 @@ export class Player implements MovingGameObject {
       this.diameterDown = this.ypos + this.height;
       this.diameterLeft = this.xpos + 4;
     }
+    this.animTimer += Game.properties.rawDelta;
     if (this.combat) {
       let newDirection = 'none';
       if (controls.playerDown) {
@@ -317,9 +320,10 @@ export class Player implements MovingGameObject {
       }
       if (
         this.attack &&
-        Game.properties.duration % 2 === 0 &&
+        this.animTimer >= this.ANIM_ATTACK_DURATION &&
         this.cooldown <= 0
       ) {
+        this.animTimer = 0;
         this.indexY += 1;
         if (this.attackLoop === 0) {
           this.loopIndex = 0;
@@ -353,7 +357,8 @@ export class Player implements MovingGameObject {
         } else {
           this.attackLoop++;
         }
-      } else if (Game.properties.duration % 10 === 0 && !this.attack) {
+      } else if (this.animTimer >= this.ANIM_WALK_DURATION && !this.attack) {
+        this.animTimer = 0;
         if (this.loopIndex > 3) {
           this.loopIndex = 0;
         }
@@ -397,7 +402,11 @@ export class Player implements MovingGameObject {
         newdirection != 'none' &&
         (this.oldYbase != this.ypos || this.oldXbase != this.xpos)
       ) {
-        if (newdirection != 'none' && Game.properties.duration % 10 === 0) {
+        if (
+          newdirection != 'none' &&
+          this.animTimer >= this.ANIM_WALK_DURATION
+        ) {
+          this.animTimer = 0;
           this.draw();
           this.loopIndex++;
         } else if (newdirection != this.direction) {

--- a/resources/js/gamepieces/Player.ts
+++ b/resources/js/gamepieces/Player.ts
@@ -291,7 +291,7 @@ export class Player implements MovingGameObject {
       this.diameterDown = this.ypos + this.height;
       this.diameterLeft = this.xpos + 4;
     }
-    this.animTimer += Game.properties.rawDelta;
+    this.animTimer += Game.properties.delta;
     if (this.combat) {
       let newDirection = 'none';
       if (controls.playerDown) {

--- a/resources/js/types/Advclient.ts
+++ b/resources/js/types/Advclient.ts
@@ -5,7 +5,6 @@ import type { StaticGameObject } from './gamepieces/StaticGameObject';
 
 export interface GameProperties {
   HUD?: typeof HUD;
-  duration: 0;
   requestId: number;
   pauseID: null;
   timestamp: number;

--- a/resources/js/types/Advclient.ts
+++ b/resources/js/types/Advclient.ts
@@ -18,6 +18,7 @@ export interface GameProperties {
   inBuilding: boolean;
   checkingPerson: string;
   delta: number;
+  rawDelta: number;
 }
 
 export type loadWorldParameters =

--- a/resources/js/types/Advclient.ts
+++ b/resources/js/types/Advclient.ts
@@ -17,7 +17,6 @@ export interface GameProperties {
   inBuilding: boolean;
   checkingPerson: string;
   delta: number;
-  rawDelta: number;
 }
 
 export type loadWorldParameters =

--- a/resources/js/types/gamepieces/MovingGameObject.ts
+++ b/resources/js/types/gamepieces/MovingGameObject.ts
@@ -17,6 +17,7 @@ export interface MovingGameObject extends GameObject {
   left: DirectionBlockedCheck;
   movementSpeed: number;
   currentAnimation: string;
+  animTimer: number;
 }
 
 export type MovingGameObjectTypes = Player | Daqloon;


### PR DESCRIPTION
## Description :pen:

This PR refactors the animation to use deltaTime instead of the duration. The previous implementation was highly dependent on the RAF causing the animation to be less smooth on smaller devices, or if the browser isn't able to run iterations quickly enough.
