### PR TITLE
fix: non working PLAYER_HEALTH_UPDATE event functionality

### DIFF
--- a/resources/js/__tests__/gamepieces/Player.test.ts
+++ b/resources/js/__tests__/gamepieces/Player.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, beforeEach, vi, test } from 'vitest';
+import { gameEventBus } from '@/gameEventsBus';
+import { Player } from '@/gamepieces/Player';
+
+vi.mock('@/clientScripts/viewport', () => ({
+  default: {
+    drawPlayer: vi.fn(),
+    resetPlayerLayer: vi.fn(),
+    drawAttackCoolDown: vi.fn(),
+  },
+}));
+
+vi.mock('@/clientScripts/canvasText', () => ({
+  canvasTextHeader: {
+    setDraw: vi.fn(),
+  },
+}));
+
+vi.mock('@/advclient', () => ({
+  Game: {
+    setWorld: vi.fn(),
+    properties: { duration: 0 },
+  },
+}));
+
+vi.mock('@/clientScripts/controls', () => ({
+  controls: {},
+}));
+
+vi.mock('@/clientScripts/gamePieces', () => ({
+  GamePieces: { daqloon: [] },
+}));
+
+vi.mock('@/devtools/ModuleTester', () => ({
+  addModuleTester: vi.fn(),
+}));
+
+describe('Player events', () => {
+  let player: Player;
+
+  beforeEach(() => {
+    player = new Player();
+    player.health = 100;
+    vi.useFakeTimers();
+  });
+
+  test('takeDamage emits PLAYER_HEALTH_UPDATE with reduced health', () => {
+    const callback = vi.fn();
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.takeDamage(20);
+
+    expect(callback).toHaveBeenCalledWith({ health: 80 });
+  });
+
+  test('takeDamage does not emit when damage is 0', () => {
+    const callback = vi.fn();
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.takeDamage(0);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('takeDamage does not emit when damage is NaN', () => {
+    const callback = vi.fn();
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.takeDamage(NaN);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('takeDamage emits PLAYER_HEALTH_UPDATE with health reset to 100 on death', () => {
+    const callback = vi.fn();
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    // When health drops to 0 the player dies and health is immediately reset to 100
+    player.takeDamage(150);
+
+    expect(callback).toHaveBeenCalledWith({ health: 100 });
+  });
+
+  test('regenerateHealth emits PLAYER_HEALTH_UPDATE with increased health', () => {
+    const callback = vi.fn();
+    player.health = 60;
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.regenerateHealth();
+
+    expect(callback).toHaveBeenCalledWith({ health: 70 });
+  });
+
+  test('regenerateHealth clamps health at 100 and emits', () => {
+    const callback = vi.fn();
+    player.health = 95;
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.regenerateHealth();
+
+    expect(callback).toHaveBeenCalledWith({ health: 100 });
+  });
+
+  test('load emits PLAYER_HEALTH_UPDATE to sync HUD on respawn', () => {
+    const callback = vi.fn();
+    player.health = 100;
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.load(100, 200, null);
+
+    expect(callback).toHaveBeenCalledWith({ health: 100 });
+  });
+
+  test('regenerateHealth does not emit when health is 0', () => {
+    const callback = vi.fn();
+    player.health = 0;
+    gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', callback);
+
+    player.regenerateHealth();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/resources/js/__tests__/ui/components/HUD/ScreenHUD.test.ts
+++ b/resources/js/__tests__/ui/components/HUD/ScreenHUD.test.ts
@@ -1,0 +1,105 @@
+import { render, screen, waitFor } from '@testing-library/vue';
+import { describe, test, expect, afterEach } from 'vitest';
+import '@testing-library/jest-dom';
+import ScreenHUD from '@/ui/components/HUD/ScreenHUD.vue';
+import { gameEventBus } from '@/gameEventsBus';
+import { createPinia } from 'pinia';
+import { i18n } from '@/ui/main';
+
+const renderScreenHUD = (healthCurrent = 100): ReturnType<typeof render> =>
+  render(ScreenHUD, {
+    props: {
+      hunger: { current: 80, max: 100 },
+      health: { current: healthCurrent, max: 100 },
+    },
+    global: {
+      plugins: [createPinia(), i18n],
+    },
+  });
+
+describe('ScreenHUD.vue', () => {
+  const unsubscribers: Array<() => void> = [];
+
+  afterEach(() => {
+    unsubscribers.forEach(unsub => {
+      unsub();
+    });
+    unsubscribers.length = 0;
+  });
+
+  test('renders initial health value', () => {
+    renderScreenHUD(50);
+
+    expect(screen.getByText('50 / 100')).toBeInTheDocument();
+  });
+
+  test('updates health progress bar when PLAYER_HEALTH_UPDATE is emitted', async () => {
+    renderScreenHUD(50);
+
+    gameEventBus.emit('PLAYER_HEALTH_UPDATE', { health: 75 });
+
+    await waitFor(() => {
+      expect(screen.getByText('75 / 100')).toBeInTheDocument();
+    });
+  });
+
+  test('unsubscribes from PLAYER_HEALTH_UPDATE on unmount', () => {
+    const result = renderScreenHUD(50);
+
+    result.unmount();
+
+    gameEventBus.emit('PLAYER_HEALTH_UPDATE', { health: 99 });
+
+    // After unmount, the DOM is gone — confirm no stale listener throws
+    expect(() => {
+      gameEventBus.emit('PLAYER_HEALTH_UPDATE', { health: 99 });
+    }).not.toThrow();
+  });
+
+  test('shows hunted icon when PLAYER_HUNTED_UPDATE is emitted with isHunted true', async () => {
+    renderScreenHUD();
+
+    expect(screen.queryByAltText('Hunted Icon icon')).not.toBeInTheDocument();
+
+    gameEventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: true });
+
+    await waitFor(() => {
+      expect(screen.getByAltText('Hunted Icon icon')).toBeInTheDocument();
+    });
+  });
+
+  test('hides hunted icon when PLAYER_HUNTED_UPDATE is emitted with isHunted false', async () => {
+    renderScreenHUD();
+
+    gameEventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: true });
+    await waitFor(() => {
+      expect(screen.getByAltText('Hunted Icon icon')).toBeInTheDocument();
+    });
+
+    gameEventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: false });
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('Hunted Icon icon')).not.toBeInTheDocument();
+    });
+  });
+
+  test('displays building name when HUD_BUILDING_PROMPT_UPDATE is emitted', async () => {
+    renderScreenHUD();
+
+    gameEventBus.emit('HUD_BUILDING_PROMPT_UPDATE', { buildingName: 'Tavern' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Tavern', { exact: false })).toBeInTheDocument();
+    });
+  });
+
+  test('displays character name when HUD_CONVERSATION_PROMPT_UPDATE is emitted', async () => {
+    renderScreenHUD();
+
+    gameEventBus.emit('HUD_CONVERSATION_PROMPT_UPDATE', { characterName: 'Sailor Bob' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Sailor Bob', { exact: false })).toBeInTheDocument();
+    });
+  });
+});

--- a/resources/js/gamepieces/Player.ts
+++ b/resources/js/gamepieces/Player.ts
@@ -114,6 +114,7 @@ export class Player implements MovingGameObject {
     this.diameterDown = this.y + this.height;
     this.diameterLeft = this.x;
     this.setup();
+    gameEventBus.emit('PLAYER_HEALTH_UPDATE', { health: this.health });
   }
 
   setIsInCombatAction(status) {
@@ -252,9 +253,14 @@ export class Player implements MovingGameObject {
 
   regenerateHealth() {
     if (this.health <= 0) return;
-    this.health + 10 > 100 ? (this.health = 100) : (this.health += 10);
-    gameEventBus.emit('PLAYER_HEALTH_CHANGE', {
-      playerHealthChange: this.health,
+    const newHealth = this.health + 10;
+    if (newHealth > 100) {
+      this.health = 100;
+    } else {
+      this.health = newHealth;
+    }
+    gameEventBus.emit('PLAYER_HEALTH_UPDATE', {
+      health: this.health,
     });
 
     this.regenerateCoundown = false;

--- a/resources/js/gamepieces/Player.ts
+++ b/resources/js/gamepieces/Player.ts
@@ -159,8 +159,8 @@ export class Player implements MovingGameObject {
         });
       }, 2000);
     }
-    gameEventBus.emit('PLAYER_HEALTH_CHANGE', {
-      playerHealthChange: this.health,
+    gameEventBus.emit('PLAYER_HEALTH_UPDATE', {
+      health: this.health,
     });
   }
 

--- a/resources/js/ui/components/HUD/ScreenHUD.vue
+++ b/resources/js/ui/components/HUD/ScreenHUD.vue
@@ -111,6 +111,9 @@ const unsubscribers = [
   gameEventBus.subscribe('HUD_CONVERSATION_PROMPT_UPDATE', payload => {
     characterName.value = payload.characterName;
   }),
+  gameEventBus.subscribe('PLAYER_HEALTH_UPDATE', payload => {
+    currentHealth.value = payload.health;
+  }),
 ];
 
 onUnmounted(() => {


### PR DESCRIPTION
## Description :pen:

This PR fixes an issue where the `Player` was emitting the wrong event when taking damage, regenerating health OR on respawn. There were also an issue where `ScreenHUD` were not tracking this health.
