### PR TITLE
feat(gameEventsBus): Add unsubscribe method to cleanup listeners

### DIFF
--- a/resources/js/__tests__/gameEventsBus.test.ts
+++ b/resources/js/__tests__/gameEventsBus.test.ts
@@ -1,17 +1,39 @@
 import { gameEventBus } from '@/gameEventsBus';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi, afterEach } from 'vitest';
 
 describe('gameEventsBus tests', () => {
+  const unsubscribers: Array<() => void> = [];
+
+  afterEach(() => {
+    unsubscribers.forEach(unsub => {
+      unsub();
+    });
+    unsubscribers.length = 0;
+  });
+
   test('emitted event is called', () => {
-    const eventBus = gameEventBus;
     const callback = vi.fn();
     const callback2 = vi.fn();
 
-    eventBus.subscribe('PLAYER_HUNTED_UPDATE', callback);
-    eventBus.subscribe('PLAYER_HUNTED_UPDATE', callback2);
-    eventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: true });
+    unsubscribers.push(
+      gameEventBus.subscribe('PLAYER_HUNTED_UPDATE', callback),
+    );
+    unsubscribers.push(
+      gameEventBus.subscribe('PLAYER_HUNTED_UPDATE', callback2),
+    );
+    gameEventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: true });
 
     expect(callback).toHaveBeenCalledWith({ isHunted: true });
     expect(callback2).toHaveBeenCalledWith({ isHunted: true });
+  });
+
+  test('unsubscribe prevents further calls', () => {
+    const callback = vi.fn();
+
+    const unsub = gameEventBus.subscribe('PLAYER_HUNTED_UPDATE', callback);
+    unsub();
+    gameEventBus.emit('PLAYER_HUNTED_UPDATE', { isHunted: true });
+
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/resources/js/gameEventsBus.ts
+++ b/resources/js/gameEventsBus.ts
@@ -28,8 +28,19 @@ class GameEventBus {
   };
 
   subscribe<K extends GameEventType>(event: K, listener: GameEventListener<K>) {
-    // TypeScript can't guarantee at runtime, but we trust the typing at call site
     this.listeners[event].push(listener);
+    return () => {
+      this.unsubscribe(event, listener);
+    };
+  }
+
+  unsubscribe<K extends GameEventType>(
+    event: K,
+    listener: GameEventListener<K>,
+  ) {
+    const listeners = this.listeners[event];
+    const index = listeners.indexOf(listener);
+    if (index !== -1) listeners.splice(index, 1);
   }
 
   emit<K extends GameEventType>(event: K, payload: GameEventMap[K]) {

--- a/resources/js/ui/components/ClientOverlayWrapper.vue
+++ b/resources/js/ui/components/ClientOverlayWrapper.vue
@@ -43,6 +43,7 @@
 import { gameEventBus } from '@/gameEventsBus';
 import {
   computed,
+  onUnmounted,
   ref,
   shallowRef,
   useTemplateRef,
@@ -80,7 +81,7 @@ watch(externalContent, () => {
   }
 });
 
-gameEventBus.subscribe('RENDER_BUILDING', obj => {
+const unsubRenderBuilding = gameEventBus.subscribe('RENDER_BUILDING', obj => {
   isOpen.value = true;
 
   if (!('content' in obj) && !('loading' in obj)) {
@@ -101,6 +102,10 @@ gameEventBus.subscribe('RENDER_BUILDING', obj => {
     const content = new DOMParser().parseFromString(obj.content, 'text/html');
     externalContent.value = content.body;
   }
+});
+
+onUnmounted(() => {
+  unsubRenderBuilding();
 });
 
 const internalClose = () => {

--- a/resources/js/ui/components/HUD/LogModal.vue
+++ b/resources/js/ui/components/HUD/LogModal.vue
@@ -14,9 +14,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onUnmounted } from 'vue';
 import { gameEventBus } from '@/gameEventsBus';
-import type { GameLog} from '@/types/GameLog';
+import type { GameLog } from '@/types/GameLog';
 import { GameLogTypes } from '@/types/GameLog';
 import { parseGameLog } from '@/utilities/parseGameLog';
 import GameLogItem from '../GameLogItem.vue';
@@ -67,10 +67,17 @@ const showNextMessage = () => {
   }, 4000);
 };
 
-gameEventBus.subscribe('GAMELOGGER_MESSAGE_LOGGED', eventData => {
-  messages.value.push(eventData.message);
-  if (!isShowing.value) {
-    showNextMessage();
-  }
+const unsubGameLogger = gameEventBus.subscribe(
+  'GAMELOGGER_MESSAGE_LOGGED',
+  eventData => {
+    messages.value.push(eventData.message);
+    if (!isShowing.value) {
+      showNextMessage();
+    }
+  },
+);
+
+onUnmounted(() => {
+  unsubGameLogger();
 });
 </script>

--- a/resources/js/ui/components/HUD/ScreenHUD.vue
+++ b/resources/js/ui/components/HUD/ScreenHUD.vue
@@ -76,7 +76,7 @@
 <script setup lang="ts" vapor>
 import { gameEventBus } from '@/gameEventsBus';
 import { useMapStore } from '@/ui/stores/MapStore';
-import { ref } from 'vue';
+import { ref, onUnmounted } from 'vue';
 
 interface Props {
   hunger: {
@@ -97,19 +97,25 @@ const showHuntedIcon = ref(false);
 const buildingName = ref<string | null>(null);
 const characterName = ref<string | null>(null);
 
-gameEventBus.subscribe('PLAYER_HUNTED_UPDATE', ({ isHunted }) => {
-  if (isHunted) {
-    showHuntedIcon.value = true;
-  } else {
-    showHuntedIcon.value = false;
-  }
-});
+const unsubscribers = [
+  gameEventBus.subscribe('PLAYER_HUNTED_UPDATE', ({ isHunted }) => {
+    if (isHunted) {
+      showHuntedIcon.value = true;
+    } else {
+      showHuntedIcon.value = false;
+    }
+  }),
+  gameEventBus.subscribe('HUD_BUILDING_PROMPT_UPDATE', payload => {
+    buildingName.value = payload.buildingName;
+  }),
+  gameEventBus.subscribe('HUD_CONVERSATION_PROMPT_UPDATE', payload => {
+    characterName.value = payload.characterName;
+  }),
+];
 
-gameEventBus.subscribe('HUD_BUILDING_PROMPT_UPDATE', payload => {
-  buildingName.value = payload.buildingName;
-});
-
-gameEventBus.subscribe('HUD_CONVERSATION_PROMPT_UPDATE', payload => {
-  characterName.value = payload.characterName;
+onUnmounted(() => {
+  unsubscribers.forEach(unsub => {
+    unsub();
+  });
 });
 </script>

--- a/resources/js/ui/components/sidebar/GameLogTab.vue
+++ b/resources/js/ui/components/sidebar/GameLogTab.vue
@@ -19,7 +19,7 @@
 import { gameEventBus } from '@/gameEventsBus';
 import type { GameLog, ParsedGameLog } from '@/types/GameLog';
 import { parseGameLog } from '@/utilities/parseGameLog';
-import { ref } from 'vue';
+import { onUnmounted, ref } from 'vue';
 import GameLogItem from '../GameLogItem.vue';
 
 interface Props {
@@ -29,13 +29,20 @@ const { initMessages } = defineProps<Props>();
 
 const messages = ref<ParsedGameLog[]>(initMessages);
 
-gameEventBus.subscribe('GAMELOGGER_MESSAGE_LOGGED', ({ message }) => {
-  const parsedGameLog = {
-    ...message,
-    message: parseGameLog(message.message),
-    timestamp: message.timestamp ?? new Date().toLocaleTimeString(),
-  };
+const unsubGameLogger = gameEventBus.subscribe(
+  'GAMELOGGER_MESSAGE_LOGGED',
+  ({ message }) => {
+    const parsedGameLog = {
+      ...message,
+      message: parseGameLog(message.message),
+      timestamp: message.timestamp ?? new Date().toLocaleTimeString(),
+    };
 
-  messages.value = [...messages.value, parsedGameLog];
+    messages.value = [...messages.value, parsedGameLog];
+  },
+);
+
+onUnmounted(() => {
+  unsubGameLogger();
 });
 </script>


### PR DESCRIPTION
## Description :pen:

This PR adds a unsubscribe method to remove old listeneres. Especially when vue components unmount there is no reason to keep the old listeners.
