### PR TITLE
fix(BaseItem): popover isnt closing when disableTooltip is activated

### DIFF
--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :class="['item group', { 'u-focus-ring': showFocusRing }]">
+  <div class="item">
     <figure @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
       <img
         :src="'/images/' + item + '.png'"
@@ -28,7 +28,7 @@
         <img class="gold" src="/images/gold.png" :alt="$t('gold icon')" />
       </li>
     </ul>
-  </button>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -54,7 +54,6 @@ const {
   showAmount = true,
   item,
   amount = undefined,
-  showFocusRing = true,
 } = defineProps<Props>();
 
 watch(

--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="item">
+  <button :class="['item group', { 'u-focus-ring': showFocusRing }]">
     <figure @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
       <img
         :src="'/images/' + item + '.png'"
@@ -28,12 +28,12 @@
         <img class="gold" src="/images/gold.png" :alt="$t('gold icon')" />
       </li>
     </ul>
-  </div>
+  </button>
 </template>
 
 <script setup lang="ts">
 import { jsUcWords } from '@/utilities/uppercase';
-import { computed, useId, useTemplateRef } from 'vue';
+import { computed, watch, useId, useTemplateRef } from 'vue';
 import { formatItemAmount } from '@/utilities/formatters';
 import type { Item } from '@/types/Item';
 import { itemPrices } from '@/clientScripts/inventory';
@@ -44,6 +44,7 @@ interface Props {
   item: Item['item'];
   amount?: number;
   showAmount?: boolean;
+  showFocusRing?: boolean;
 }
 
 const { t } = useI18n();
@@ -53,7 +54,17 @@ const {
   showAmount = true,
   item,
   amount = undefined,
+  showFocusRing = true,
 } = defineProps<Props>();
+
+watch(
+  () => disableTooltip,
+  () => {
+    if (disableTooltip) {
+      tooltip.value?.hidePopover();
+    }
+  },
+);
 
 const itemAmountWithDelimiter = computed((): string | number => {
   if (amount === undefined) {

--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -44,7 +44,6 @@ interface Props {
   item: Item['item'];
   amount?: number;
   showAmount?: boolean;
-  showFocusRing?: boolean;
 }
 
 const { t } = useI18n();


### PR DESCRIPTION
## Description :pen:

This PR fixes an issue where the popover weren't closing when the disableTooltip was activated. This caused an already popover not to be closed until the user did move the event away.
