### PR TITLE
fix(BaseRadio) not updating its v-model on click

### DIFF
--- a/resources/js/__tests__/ui/components/base/BaseRadio.test.ts
+++ b/resources/js/__tests__/ui/components/base/BaseRadio.test.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, test } from 'vitest';
+import BaseRadio from '@/ui/components/base/BaseRadio.vue';
+
+describe('BaseRadio component', () => {
+  test('checks the input matching the current model value', () => {
+    const wrapper = mount(BaseRadio, {
+      props: {
+        id: 'right',
+        name: 'hand',
+        value: 'right_hand',
+        modelValue: 'right_hand',
+      },
+    });
+
+    expect((wrapper.find('input').element as HTMLInputElement).checked).toBe(
+      true,
+    );
+  });
+
+  test('emits update:modelValue with its value when selected', async () => {
+    const wrapper = mount(BaseRadio, {
+      props: {
+        id: 'left',
+        name: 'hand',
+        value: 'left_hand',
+        modelValue: 'right_hand',
+      },
+    });
+
+    await wrapper.find('input').setValue();
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['left_hand']);
+  });
+});

--- a/resources/js/ui/components/base/BaseRadio.vue
+++ b/resources/js/ui/components/base/BaseRadio.vue
@@ -8,11 +8,11 @@
     </span>
     <input
       :id
+      v-model="checkedValue"
       type="radio"
       :name
       :value
       class="peer absolute h-0 w-0 cursor-pointer opacity-0"
-      :checked="isChecked === value"
     />
     <span
       class="relative inline-block h-5 w-5 rounded-full border-2 border-transparent bg-neutral-100 peer-checked:bg-orange-600 peer-checked:drop-shadow-xl after:absolute after:top-0.5 after:left-0.5 after:hidden after:h-3 after:w-3 after:rounded-full after:bg-white after:content-[''] peer-checked:after:block hover:bg-gray-200"
@@ -28,7 +28,7 @@ interface Props {
   value: string | number;
 }
 
-const isChecked = defineModel<string | number>();
+const checkedValue = defineModel<string | number>();
 
 defineProps<Props>();
 </script>


### PR DESCRIPTION
## Description :pen:

This PR fixes an issue where the v-model didn't update on click.

This PR changes so that we use v-model on the input directly and let vue do the binding work.

Additionally the "isChecked" naming for local ref was confusing since it implied a Boolean but was actually tracking the checkedValue. New name is changed to "checkedValue".