### PR TITLE
build(phpstan): exclude paths that should be typechecked

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,6 +26,10 @@ parameters:
             path: app/Http/Middleware/HandleInertiaRequests.php
 
     excludePaths:
+        - app/Models/Adventures_model.php
+        - app/Models/Artefact_model.php
+        - app/Models/SetAdventure_model.php
+        - app/Models/UpdateGamedata_model.php
         - ./vendor/*
         - ./libs/*
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,6 +30,7 @@ parameters:
         - app/Models/Artefact_model.php
         - app/Models/SetAdventure_model.php
         - app/Models/UpdateGamedata_model.php
+        - app/Models/UpdateAdventure_model.php
         - ./vendor/*
         - ./libs/*
 


### PR DESCRIPTION
## Description :pen:

This PR configures phpstan to exclude specific *_model files that is causing a problem. It is not ready for being typechecked and is to be replaced. The code is not in use either.
