### PR TITLE
Dedupe frontend error reports and send stack traces separately

### DIFF
--- a/app/Http/Controllers/LogController.php
+++ b/app/Http/Controllers/LogController.php
@@ -10,8 +10,14 @@ class LogController extends Controller
 {
     public function logFrontendError(Request $request): JsonResponse
     {
-        $text = $request->input('text');
-        Log::error($text);
+        $validated = $request->validate([
+            'text' => 'required|string',
+            'stack' => 'nullable|string',
+        ]);
+
+        Log::error($validated['text'], array_filter([
+            'stack' => $validated['stack'] ?? null,
+        ]));
 
         return response()->json([], 200);
     }

--- a/resources/js/base/ErrorHandler.ts
+++ b/resources/js/base/ErrorHandler.ts
@@ -1,20 +1,24 @@
 import { ErrorHandler } from '@/lib/ErrorHandler';
 
+export type ErrorPayload = {
+  text: string;
+  stack?: string;
+};
+
 export const initErrorHandler = () => {
-  const handler = new ErrorHandler<{
-    text: string;
-  }>('/log/error');
+  const handler = new ErrorHandler<ErrorPayload>('/log/error');
 
   handler.registerErrorListener((e: ErrorEvent | PromiseRejectionEvent) => {
     let text = '';
+    let stack: string | undefined;
     if (e instanceof ErrorEvent) {
-      text = text = `Frontend error: ${e.message} ${e.error}`;
+      text = `Frontend error: ${e.message}`;
+      stack = e.error?.stack;
     } else if (e instanceof PromiseRejectionEvent) {
-      text = `Unhandled promise rejection: ${e.reason.message} ${e.reason.stack}`;
+      text = `Unhandled promise rejection: ${e.reason?.message}`;
+      stack = e.reason?.stack;
     }
-    handler.logError({
-      text,
-    });
+    handler.logError({ text, stack });
   });
 
   return handler;
@@ -22,12 +26,9 @@ export const initErrorHandler = () => {
 
 export const reportCatchError = (e: unknown) => {
   const handler = initErrorHandler();
-  let text = '';
   if (e instanceof Error) {
-    text = `Frontend error: ${e.message} ${e.stack}`;
-    handler.logError({ text });
+    handler.logError({ text: `Frontend error: ${e.message}`, stack: e.stack });
   } else {
-    text = `Frontend error: ${e}`;
+    handler.logError({ text: `Frontend error: ${e}` });
   }
-  handler.logError({ text });
 };

--- a/resources/js/lib/ErrorHandler.ts
+++ b/resources/js/lib/ErrorHandler.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 type ErrorCallback = (error: ErrorEvent | PromiseRejectionEvent) => void;
 export class ErrorHandler<T> {
   private static isListening = false;
+  private static seenErrors = new Set<string>();
 
   endpoint: string;
 
@@ -22,6 +23,9 @@ export class ErrorHandler<T> {
   }
 
   public logError(format: T) {
+    const key = JSON.stringify(format);
+    if (ErrorHandler.seenErrors.has(key)) return;
+    ErrorHandler.seenErrors.add(key);
     axios.post(this.endpoint, format);
   }
 }

--- a/resources/js/ui/main.ts
+++ b/resources/js/ui/main.ts
@@ -32,8 +32,9 @@ document.querySelectorAll('.vue-app').forEach(element => {
 
   app.config.errorHandler = async (err, vm, info) => {
     const errorToLog = err + ' ' + JSON.stringify(vm) + ' ' + info;
+    const stack = err instanceof Error ? err.stack : undefined;
 
-    ErrorHandler.logError({ text: errorToLog });
+    ErrorHandler.logError({ text: errorToLog, stack });
   };
 
   app.use(pinia).use(ui).use(i18n).mount(element);


### PR DESCRIPTION
Skip re-posting an error to /log/error once the same payload has already been sent this session, so an error occurring in a loop doesn't spam the backend. Also split the stack trace into its own field instead of concatenating it into the message text, and have the backend validate and log it via Laravel's log context.

## Description :pen:

_Describe the proposed changes here_
