### PR TITLE
feat(BaseItem): add isInteractive and showFocus prop

### DIFF
--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="isIneractive ? 'button' : 'div'"
-    :class="['item group', { 'u-focus-ring': useFocusStyle && isIneractive }]"
+    :class="['item group', { 'u-focus-ring': showFocusStyle && isIneractive }]"
   >
     <figure @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
       <img
@@ -47,7 +47,7 @@ interface Props {
   item: Item['item'];
   amount?: number;
   showAmount?: boolean;
-  useFocusStyle?: boolean;
+  showFocusStyle?: boolean;
   isIneractive?: boolean;
 }
 
@@ -58,7 +58,7 @@ const {
   showAmount = true,
   item,
   amount = undefined,
-  useFocusStyle = true,
+  showFocusStyle = true,
   isIneractive = true,
 } = defineProps<Props>();
 

--- a/resources/js/ui/components/base/BaseItem.vue
+++ b/resources/js/ui/components/base/BaseItem.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="item">
+  <component
+    :is="isIneractive ? 'button' : 'div'"
+    :class="['item group', { 'u-focus-ring': useFocusStyle && isIneractive }]"
+  >
     <figure @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
       <img
         :src="'/images/' + item + '.png'"
@@ -28,7 +31,7 @@
         <img class="gold" src="/images/gold.png" :alt="$t('gold icon')" />
       </li>
     </ul>
-  </div>
+  </component>
 </template>
 
 <script setup lang="ts">
@@ -44,6 +47,8 @@ interface Props {
   item: Item['item'];
   amount?: number;
   showAmount?: boolean;
+  useFocusStyle?: boolean;
+  isIneractive?: boolean;
 }
 
 const { t } = useI18n();
@@ -53,6 +58,8 @@ const {
   showAmount = true,
   item,
   amount = undefined,
+  useFocusStyle = true,
+  isIneractive = true,
 } = defineProps<Props>();
 
 watch(

--- a/resources/js/ui/components/profiency-status/FarmerStatus.vue
+++ b/resources/js/ui/components/profiency-status/FarmerStatus.vue
@@ -5,7 +5,7 @@
     </h3>
     <template v-if="status.crop_type !== null">
       <div v-show="!isFinished" class="flex flex-row items-center">
-        <BaseItem :item="status.crop_type" />
+        <BaseItem :item="status.crop_type" :is-ineractive="false" />
         <p class="flex flex-row items-center gap-2">
           <BaseIcon icon="timer" />
           {{ remainder.minutes }}

--- a/resources/js/ui/components/profiency-status/MinerStatus.vue
+++ b/resources/js/ui/components/profiency-status/MinerStatus.vue
@@ -5,7 +5,7 @@
     </h3>
     <template v-if="status.mineral_ore != null">
       <div v-show="!isFinished" class="flex flex-row items-center">
-        <BaseItem :item="status.mineral_ore" />
+        <BaseItem :item="status.mineral_ore" :is-ineractive="false" />
         <p class="flex flex-row items-center gap-2">
           <BaseIcon icon="timer" />
           {{ remainder.minutes }}

--- a/resources/js/ui/components/profiency-status/TraderStatus.vue
+++ b/resources/js/ui/components/profiency-status/TraderStatus.vue
@@ -12,7 +12,10 @@
       <h3 class="text-lg font-bold">{{ $t('Current assignment') }}</h3>
       <div class="mt-2 grid grid-cols-2 gap-2 gap-x-3 px-2">
         <div>
-          <BaseItem :item="status.trader_assignment.cargo" />
+          <BaseItem
+            :item="status.trader_assignment.cargo"
+            :is-ineractive="false"
+          />
         </div>
         <div>
           <BaseIcon icon="route" :title="$t('Route icon')" />


### PR DESCRIPTION
## Description :pen:

This PR adds `isInteractive` and `showFocusStyle` to the BaseItem for usecase in many different situations. `isInteractive` can be used to switch between div and button. Should be toggled off when only hover effects happens.

This is a precursor to the stockpile rewrite and useFocusStyle.
