### PR TITLE
build: migrate to php artisan dev command

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,7 +51,7 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 ## Frontend Bundling
 
-- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `composer run dev`. Ask them.
+- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `php artisan dev`. Ask them.
 
 ## Documentation Files
 
@@ -213,7 +213,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ## Vite Error
 
-- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `php artisan dev`.
 
 === laravel/v11 rules ===
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ For multi-step plans, divide them into multiple phases with different headings. 
 - **Run tests with coverage**: `php artisan test --coverage`
 - **PHP static analysis**: `composer phpstan` or `./vendor/bin/phpstan analyse`
 - **PHP code formatting**: `vendor/bin/pint --dirty` (run before finalizing changes)
-- **Start development server**: `composer dev` (runs server, queue, logs, reverb, vite)
+- **Start development server**: `php artisan dev` (runs server, queue, logs, reverb, vite)
 - **Generate IDE helpers**: `php artisan ide-helper:generate && php artisan ide-helper:meta`
 
 ### Frontend Commands
@@ -186,7 +186,7 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 ## Frontend Bundling
 
-- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `composer run dev`. Ask them.
+- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `php artisan dev`. Ask them.
 
 ## Documentation Files
 
@@ -348,7 +348,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ## Vite Error
 
-- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `php artisan dev`.
 
 === laravel/v11 rules ===
 

--- a/composer.json
+++ b/composer.json
@@ -73,11 +73,7 @@
     "post-create-project-cmd": [
       "@php artisan key:generate --ansi"
     ],
-    "phpstan": "./vendor/bin/phpstan analyse --memory-limit=2G",
-    "dev": [
-      "Composer\\Config::disableProcessTimeout",
-      "npx concurrently -k -c \"#93c5fd,#c4b5fd,#d4d4d8,#86efac,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail\" \"php artisan reverb:start\" \"pnpm run dev\" --names=server,queue,logs,reverb,vite"
-    ]
+    "phpstan": "./vendor/bin/phpstan analyse --memory-limit=2G"
   },
   "extra": {
     "laravel": {

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Foundation\DevCommands;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
@@ -17,3 +18,5 @@ use Illuminate\Support\Facades\Artisan;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+DevCommands::artisan('reverb:start', 'reverb');


### PR DESCRIPTION
## Description :pen:

Migrate from `composer run dev` to the new `php artisan dev` command.
