### PR TITLE
build(vite.config.ts): set include option for test

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./resources/js/mocks/setup.ts'],
-    exclude: ['**/node_modules/**', '**/vendor/**'],
+    include: ['./resources/js/**/*.test.ts'],
     globals: true,
     coverage: {
       exclude: ['vendor/**'],


### PR DESCRIPTION
## Description :pen:

Set include option for test to only run on `resources/js/**/*` to prevent local setup running on .claude / .codex worktrees
