### PR TITLE
fix: break circular import cycle

### DIFF
--- a/resources/js/clientScripts/viewport.ts
+++ b/resources/js/clientScripts/viewport.ts
@@ -1,6 +1,7 @@
-import { Game } from '../advclient';
 import type { CanvasSprite } from '../types/CanvasSprite';
 import { AssetPaths } from './ImagePath';
+
+type device = 'mobile' | 'pc';
 
 interface IViewport {
   counter: number;
@@ -29,8 +30,8 @@ interface IViewport {
     frontObjects: CanvasRenderingContext2D;
     text: CanvasRenderingContext2D;
   };
-  setInitalDimensions();
-  setup(layers: HTMLCanvasElement[]);
+  setInitalDimensions(device: device);
+  setup(layers: layers, device: device);
   adjustViewport(xbase: number, ybase: number, src: string);
   init: () => void;
   drawBackground();
@@ -95,7 +96,7 @@ export const viewport = {
     text: null as CanvasRenderingContext2D,
     hud: null as CanvasRenderingContext2D,
   },
-  setInitalDimensions() {
+  setInitalDimensions(device: device) {
     const screen = window.screen;
     let newWidth;
     if (screen.width < 800) {
@@ -115,7 +116,7 @@ export const viewport = {
     newWidth = gameCanvas.parentElement?.offsetWidth - 12;
     let newHeight;
     // If the device is mobile check for the shortest dimension of height and width to compensate for already rotated devices
-    if (Game.properties.device == 'mobile') {
+    if (device == 'mobile') {
       newHeight =
         screen.width < screen.height ? screen.width - 20 : screen.height - 20;
     } else {
@@ -127,9 +128,9 @@ export const viewport = {
     this.width = newWidth;
     this.height = newHeight;
   },
-  setup(layers: layers) {
+  setup(layers: layers, device: device) {
     // Set layers and elements
-    this.setInitalDimensions();
+    this.setInitalDimensions(device);
 
     this.layer.background = layers.background.getContext('2d');
     this.layer.background.fillStyle = 'black';
@@ -194,10 +195,8 @@ export const viewport = {
     this.layer.frontObjects.scale(this.zoom, this.zoom);
     this.layer.hud.scale(this.zoom, this.zoom);
   },
-  setImageWorldSrc() {
-    this.worldImage.src = AssetPaths.getImagePath(
-      Game.properties.currentMap + '.png',
-    );
+  setImageWorldSrc(currentMap: string) {
+    this.worldImage.src = AssetPaths.getImagePath(currentMap + '.png');
   },
   adjustViewport(xbase, ybase) {
     this.playerCanvasX = Math.floor(this.width / 2 - 45);

--- a/resources/js/gamepieces/BaseStaticGameObject.ts
+++ b/resources/js/gamepieces/BaseStaticGameObject.ts
@@ -53,9 +53,6 @@ export class BaseStaticGameObject implements GameObject {
     this.sprite = new Image(this.width, this.height);
 
     this.sprite.src = AssetPaths.getImagePath(this.src);
-    if (!this.src && !GamePieces.nonDrawingTypes.includes(this.type)) {
-      console.error('No image source found for ' + this.src);
-    }
     // check source for missing format
     if (!this.sprite.src.includes('.png')) this.sprite.src += '.png';
   }


### PR DESCRIPTION
## Description :pen:

Fixes a circular import cycle by refactor `viewport` and `BaseStaticGameObject`
* `viewport` can just accepts the data from `Game`
* `BaseStaticGameObject` doesn't need the `nonDrawingTypes` only to log. We know have a crash implementation that picks up if it happens
